### PR TITLE
typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Data you can retrieve from this API.
 ## Trending Repositories
 
 ```json
-❯ curl -X GET "https://gh-trending-api.herokuapp.com/developers" -H  "accept: application/json"
+❯ curl -X GET "https://gh-trending-api.herokuapp.com/repositories" -H  "accept: application/json"
 [
   {
     "rank": 1,
@@ -68,7 +68,7 @@ Data you can retrieve from this API.
 ## Trending Developers
 
 ```json
-❯ curl -X GET "https://gh-trending-api.herokuapp.com/repositories" -H  "accept: application/json"
+❯ curl -X GET "https://gh-trending-api.herokuapp.com/developers" -H  "accept: application/json"
 [
   {
     "rank": 1,


### PR DESCRIPTION
I have noticed that `repositories` and `developers` were swapped in the shell commands in the **Examples** section in [`README.md`](https://github.com/NiklasTiede/Github-Trending-API/blob/a2a2ec04411230573b5ed55d41ae617fba7d51da/README.md). This pull request fixes that.